### PR TITLE
Added in a new flag to skip attempting upload of the artifact at the …

### DIFF
--- a/__tests__/vstest.tests.ts
+++ b/__tests__/vstest.tests.ts
@@ -25,7 +25,7 @@ describe('vstest Action Unit Tests', ()=>{
 
         jest.mock('@actions/exec');
         jest.spyOn(exec, 'exec');
-
+        jest.spyOn(exec, 'getExecOutput');
         jest.mock('path');
 
 

--- a/action.yml
+++ b/action.yml
@@ -74,6 +74,10 @@ inputs:
       Minimum 1 day.
       Maximum 90 days unless changed from the repository settings page.
 
+  shouldSkipArtifactUpload:
+    description: "Skip attempt to upload test result artifact."
+    required: false
+
 runs:
   using: "node20"
   main: "dist/index.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,18 +24,15 @@ export async function run() {
     core.info(`Unzipping test tools...`);
     core.debug(`workerZipPath is ${workerZipPath}`);
 
-    const existingVsTestPath = path.join(__dirname, 'win-x64');
-    core.debug(`testPath is ${existingVsTestPath}`);
+    const vsTestPath = getVsTestPath();
+    core.debug(`VsTestPath: ${vsTestPath}`);
 
     // if the test tools already exist in the target folder do not try to overwrite them.
     await exec.exec(`
-      if (!(Test-Path -Path ${existingVsTestPath})) {
+      if (!(Test-Path -Path ${vsTestPath})) {
         powershell Expand-Archive -Path ${workerZipPath} -DestinationPath ${__dirname}
       }
     `);
-
-    const vsTestPath = getVsTestPath();
-    core.debug(`VsTestPath: ${vsTestPath}`);
 
     const args = getArguments();
     core.debug(`Arguments: ${args}`);


### PR DESCRIPTION
Add new flag, opt-in, to skip uploading the artifact.

Add new logic to smartly unarchive the tool if already unzipped due to multiple instances don't unarchive it again.

Referencing this issue: https://github.com/microsoft/vstest-action/issues/7